### PR TITLE
Attempted /givespeed <player>

### DIFF
--- a/CommandHelper/LocalPackages/commands/powers/givespeed.msa
+++ b/CommandHelper/LocalPackages/commands/powers/givespeed.msa
@@ -1,0 +1,7 @@
+# Gives player speed 3 for 5 minutes
+givespeed:/givespeed $plr = >>>
+    @plr = $plr
+    sudo(/effect @plr 1 300 3 true)
+    tmsg(player(), "You have given speed to ".@plr."!")
+    tmsg(@plr, "You have been given speed by ". player() ."!")
+<<<


### PR DESCRIPTION
Tek I need you to make it so this command only works when it's used next to someone just like /speedforceteleport, and make it so it doesn't work on speedsters