### PR TITLE
Updated Savitar's Permissions

### DIFF
--- a/PermissionsEx/permissions.yml
+++ b/PermissionsEx/permissions.yml
@@ -3828,10 +3828,13 @@ groups:
         - powers.wallrun
         - worldedit.navigation.thru.command
         - essentials.tppos
+        - ch.alias.carryplayer
         - ch.alias.speedforcewhirlwind
         - ch.alias.speedforceteleport
         - essentials.warps.speedforce
         - ch.alias.savitar
+        - ch.alias.invis 
+        - ch.alias.vis 
         - ch.alias.jump0
         - ch.alias.jump1
         - ch.alias.jump2
@@ -3934,9 +3937,6 @@ groups:
         permissions:
         - powers.wallrun
         - worldedit.navigation.thru.command
-        - ch.alias.speedforcebuffs
-        - ch.alias.run1
-        - ch.alias.run0
         - ch.alias.powers
         - ch.alias.speedforceteleport
         - ch.alias.carryplayer


### PR DESCRIPTION
Gave him /invis & /vis. Also gave him /carryplayer. Fixed the zoom bugfix of /speedforcebuffs in 1.9 Worlds