### PR TITLE
Update jessequick.ms added more strenght

### DIFF
--- a/CommandHelper/LocalPackages/commands/buffs/jessequick.ms
+++ b/CommandHelper/LocalPackages/commands/buffs/jessequick.ms
@@ -27,7 +27,7 @@
                 "/stopvibrating"
             ),
             'buffs': array(
-                "/effect ". @plr ." 5 9999 3 true",
+                "/effect ". @plr ." 5 9999 5 true",
                 "/effect ". @plr ." 10 9999 1 true",
                 "/effect ". @plr ." 21 9999 4 true",
                 "/effect ". @plr ." 10 9999 3 true",

--- a/CommandHelper/LocalPackages/commands/buffs/jessequick.ms
+++ b/CommandHelper/LocalPackages/commands/buffs/jessequick.ms
@@ -27,7 +27,7 @@
                 "/stopvibrating"
             ),
             'buffs': array(
-                "/effect ". @plr ." 5 9999 5 true",
+                "/effect ". @plr ." 5 9999 2 true",
                 "/effect ". @plr ." 10 9999 1 true",
                 "/effect ". @plr ." 21 9999 4 true",
                 "/effect ". @plr ." 10 9999 3 true",


### PR DESCRIPTION
Thanks to her mother, Jesse Quick gets more strenght than people would usally do, measuring it with the strenght speedforce users get normally, she gets a bit more.