### PR TITLE
Added /invis & /vis to Mew

### DIFF
--- a/CommandHelper/LocalPackages/commands/buffs/mew.ms
+++ b/CommandHelper/LocalPackages/commands/buffs/mew.ms
@@ -22,7 +22,9 @@
                 "/jump 0-2",
                 "/run 0-2",
                 "/confuse <player>",
-                "/haste 0-2"
+                "/haste 0-2",
+                "/invis",
+                "/vis"
             ),
             'buffs': array(
                 "/effect ". @plr ." 5 9999 5 true",


### PR DESCRIPTION
Added /invis & /vis to Mew as per a player request.
Player provided proof and I found supporting documentation regarding Mew's ability to utilize Invisibility. 
Proof: https://www.google.ca/url?sa=t&rct=j&q=&esrc=s&source=web&cd=1&cad=rja&uact=8&ved=0ahUKEwjokLfejtDTAhUK8YMKHcMaCwgQFggwMAA&url=http%3A%2F%2Fbulbapedia.bulbagarden.net%2Fwiki%2FMew_(Pok%25C3%25A9mon)&usg=AFQjCNEPwQyMuSOiy4IFgVrFkN58S9GzSg&sig2=Zf4_l_CZmJAt4IqoW1Snwg

https://www.google.ca/url?sa=t&rct=j&q=&esrc=s&source=web&cd=2&cad=rja&uact=8&ved=0ahUKEwjokLfejtDTAhUK8YMKHcMaCwgQFgg2MAE&url=https%3A%2F%2Fen.wikipedia.org%2Fwiki%2FMew_(Pok%25C3%25A9mon)&usg=AFQjCNHu0orkY8e3sAwZm0X22jmvpBDFyw&sig2=Y-HfjW0rkIO7iIGh_Neqdw