### PR TITLE
Update maui.ms changed fishing rods name to Maui's Fish Hook because …

### DIFF
--- a/CommandHelper/LocalPackages/commands/buffs/maui.ms
+++ b/CommandHelper/LocalPackages/commands/buffs/maui.ms
@@ -26,7 +26,7 @@
                 "/effect ". @plr ." 11 9999 3 true",
                 "/effect ". @plr ." 13 9999 1 true",
                 "/effect ". @plr ." 21 9999 14 true",
-                "/give ". @plr ." minecraft:fishing_rod 1 16:15 name:&3Maui's_&1Fishing_&4Rod"
+                "/give ". @plr ." minecraft:fishing_rod 1 16:15 name:&3Maui's_&1Fish_&4Hook"
             )
         )
           


### PR DESCRIPTION
…in the movie its called a fish hook