### PR TITLE
Renamed Universal Push to, Almighty Push

### DIFF
--- a/Magic/spells.yml
+++ b/Magic/spells.yml
@@ -1490,7 +1490,7 @@ manipulate:
         bypass_backfire: true
     costs:
         mana: 100
-universalpush:
+almightypush:
     icon: diamond_axe:33
     icon_disabled: diamond_hoe:33
     icon_url: http://textures.minecraft.net/texture/e13e9af0957a9dd4995811ef3e869b4ad8fbb59ca7474e4c84ce7f6019b079
@@ -1531,4 +1531,4 @@ universalpush:
         duration: 10000
         cooldown: 2000
     costs:
-        mana: 10
+        mana: 5


### PR DESCRIPTION
Changed Mana to 5 because it takes him 5 seconds to use another power