### PR TITLE
Changed chat color to Red & Gave Vis/Invis Perms

### DIFF
--- a/PermissionsEx/permissions.yml
+++ b/PermissionsEx/permissions.yml
@@ -4,13 +4,15 @@ groups:
     - commonherotraits
     options:
       prefix: '&8A&4r&ck&8h&ba&8m &8K&7n&bi&8g&4h&7t'
-      suffix: '&b'
+      suffix: '&c'
     worlds:
       superherocity:
         permissions:
         - magic.commands.cast
         - magic.cast.stungrenade
         - ch.alias.grapplinghook
+        - ch.alias.invis
+        - ch.alias.vis
   xenomorph:
     inheritance:
     - commonherotraits


### PR DESCRIPTION
https://www.youtube.com/watch?v=fu-TKWyZjm0 
(Skip to 7:30)
@ 7:35 Arkham Knight talks about his "Optic Deflection Armor" used to turn invisible.

Turned chat color to light red because it's his/his militia's color